### PR TITLE
[codex] add LAN DHCP configuration

### DIFF
--- a/app/local-network/lan-settings/page.tsx
+++ b/app/local-network/lan-settings/page.tsx
@@ -1,0 +1,5 @@
+import LanConfigComponent from "@/components/local-network/lan-config/lan-config";
+
+export default function LanSettingsPage() {
+  return <LanConfigComponent />;
+}

--- a/app/local-network/page.tsx
+++ b/app/local-network/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function LocalNetworkPage() {
-  redirect("/local-network/ttl-settings");
+  redirect("/local-network/lan-settings");
 }

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -190,9 +190,17 @@ const data = {
   localNetwork: [
     {
       title: "Settings",
-      url: "/local-network/ip-passthrough",
+      url: "/local-network/lan-settings",
       icon: Settings2,
       items: [
+        {
+          title: "LAN / DHCP",
+          url: "/local-network/lan-settings",
+        },
+        {
+          title: "IP Passthrough",
+          url: "/local-network/ip-passthrough",
+        },
         {
           title: "TTL & MTU Settings",
           url: "/local-network/ttl-settings",

--- a/components/local-network/lan-config/lan-config.tsx
+++ b/components/local-network/lan-config/lan-config.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type * as React from "react";
+import { AlertCircleIcon, RefreshCwIcon } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { useLanConfig } from "@/hooks/use-lan-config";
+import { toast } from "sonner";
+
+function ValueRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-4 border-b py-3 last:border-0">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <span className="text-right text-sm font-medium">{value}</span>
+    </div>
+  );
+}
+
+function LoadingCard() {
+  return (
+    <Card>
+      <CardHeader>
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-4 w-64" />
+      </CardHeader>
+      <CardContent className="grid gap-3">
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+      </CardContent>
+    </Card>
+  );
+}
+
+function formatLease(seconds: number | null) {
+  if (!seconds) return "-";
+  if (seconds % 3600 === 0) return `${seconds / 3600} hours`;
+  if (seconds % 60 === 0) return `${seconds / 60} minutes`;
+  return `${seconds} seconds`;
+}
+
+export default function LanConfigComponent() {
+  const { data, error, isLoading, isRefreshing, isSaving, refresh, saveConfig } =
+    useLanConfig();
+  const [lanIp, setLanIp] = useState("");
+  const [subnetMask, setSubnetMask] = useState("");
+  const [dhcpEnabled, setDhcpEnabled] = useState(true);
+  const [dhcpStart, setDhcpStart] = useState("");
+  const [dhcpEnd, setDhcpEnd] = useState("");
+  const [leaseTime, setLeaseTime] = useState("43200");
+
+  useEffect(() => {
+    if (!data) return;
+    setLanIp(data.lan.ip_address);
+    setSubnetMask(data.lan.subnet_mask);
+    setDhcpEnabled(data.dhcp.enabled);
+    setDhcpStart(data.dhcp.start_ip);
+    setDhcpEnd(data.dhcp.end_ip);
+    setLeaseTime(String(data.dhcp.lease_time_seconds ?? 43200));
+  }, [data]);
+
+  const isDirty = useMemo(() => {
+    if (!data) return false;
+    return (
+      lanIp !== data.lan.ip_address ||
+      subnetMask !== data.lan.subnet_mask ||
+      dhcpEnabled !== data.dhcp.enabled ||
+      dhcpStart !== data.dhcp.start_ip ||
+      dhcpEnd !== data.dhcp.end_ip ||
+      leaseTime !== String(data.dhcp.lease_time_seconds ?? 43200)
+    );
+  }, [data, lanIp, subnetMask, dhcpEnabled, dhcpStart, dhcpEnd, leaseTime]);
+
+  const handleSave = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    const lease = Number.parseInt(leaseTime, 10);
+    if (!Number.isFinite(lease)) {
+      toast.error("Lease time must be numeric");
+      return;
+    }
+
+    const result = await saveConfig({
+      lan_ip: lanIp.trim(),
+      subnet_mask: subnetMask.trim(),
+      dhcp_enabled: dhcpEnabled,
+      dhcp_start: dhcpStart.trim(),
+      dhcp_end: dhcpEnd.trim(),
+      lease_time_seconds: lease,
+    });
+
+    if (!result?.success) {
+      toast.error(result?.detail || result?.error || "Failed to save LAN config");
+      return;
+    }
+
+    if (result.at_lanip_warning) {
+      toast.warning(result.at_lanip_warning);
+    } else {
+      toast.success("LAN/DHCP settings saved. Reboot if clients do not pick up the new range.");
+    }
+  };
+
+  return (
+    <div className="@container/main mx-auto p-2">
+      <div className="mb-6 flex flex-col gap-4 @3xl/main:flex-row @3xl/main:items-start @3xl/main:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold mb-2">LAN &amp; DHCP Settings</h1>
+          <p className="text-muted-foreground">
+            Configure the modem&apos;s local gateway address and DHCP pool for
+            Ethernet clients.
+          </p>
+        </div>
+        <Button variant="outline" onClick={refresh} disabled={isRefreshing}>
+          <RefreshCwIcon className={isRefreshing ? "animate-spin" : ""} />
+          Refresh
+        </Button>
+      </div>
+
+      {error && (
+        <Alert variant="destructive" className="mb-4">
+          <AlertCircleIcon className="size-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {isLoading ? (
+        <div className="grid grid-cols-1 gap-4 @4xl/main:grid-cols-[minmax(0,1fr)_320px]">
+          <LoadingCard />
+          <LoadingCard />
+        </div>
+      ) : data ? (
+        <div className="grid grid-cols-1 gap-4 @4xl/main:grid-cols-[minmax(0,1fr)_320px]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Network Configuration</CardTitle>
+              <CardDescription>
+                Changing the LAN IP may move the GUI to the new address.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form className="grid gap-4" onSubmit={handleSave}>
+                <div className="grid grid-cols-1 gap-4 @3xl/main:grid-cols-2">
+                  <div className="grid gap-2">
+                    <Label htmlFor="lan-ip">LAN IP</Label>
+                    <Input
+                      id="lan-ip"
+                      value={lanIp}
+                      onChange={(event) => setLanIp(event.target.value)}
+                      placeholder="192.168.225.1"
+                      disabled={isSaving}
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="subnet-mask">Subnet Mask</Label>
+                    <Input
+                      id="subnet-mask"
+                      value={subnetMask}
+                      onChange={(event) => setSubnetMask(event.target.value)}
+                      placeholder="255.255.252.0"
+                      disabled={isSaving}
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="dhcp-start">DHCP Range Start</Label>
+                    <Input
+                      id="dhcp-start"
+                      value={dhcpStart}
+                      onChange={(event) => setDhcpStart(event.target.value)}
+                      placeholder="192.168.225.20"
+                      disabled={isSaving || !dhcpEnabled}
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="dhcp-end">DHCP Range End</Label>
+                    <Input
+                      id="dhcp-end"
+                      value={dhcpEnd}
+                      onChange={(event) => setDhcpEnd(event.target.value)}
+                      placeholder="192.168.225.170"
+                      disabled={isSaving || !dhcpEnabled}
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="lease-time">Lease Time (seconds)</Label>
+                    <Input
+                      id="lease-time"
+                      type="number"
+                      min={60}
+                      max={604800}
+                      value={leaseTime}
+                      onChange={(event) => setLeaseTime(event.target.value)}
+                      disabled={isSaving || !dhcpEnabled}
+                    />
+                  </div>
+                  <div className="flex items-center justify-between rounded-lg border px-4 py-3">
+                    <div>
+                      <Label htmlFor="dhcp-enabled">DHCP Server</Label>
+                      <p className="text-sm text-muted-foreground">
+                        Enable the modem DHCP server for LAN clients.
+                      </p>
+                    </div>
+                    <Switch
+                      id="dhcp-enabled"
+                      checked={dhcpEnabled}
+                      onCheckedChange={setDhcpEnabled}
+                      disabled={isSaving}
+                    />
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button type="submit" disabled={!isDirty || isSaving}>
+                    {isSaving ? "Saving..." : "Save Settings"}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={isSaving}
+                    onClick={() => {
+                      setLanIp(data.lan.ip_address);
+                      setSubnetMask(data.lan.subnet_mask);
+                      setDhcpEnabled(data.dhcp.enabled);
+                      setDhcpStart(data.dhcp.start_ip);
+                      setDhcpEnd(data.dhcp.end_ip);
+                      setLeaseTime(String(data.dhcp.lease_time_seconds ?? 43200));
+                    }}
+                  >
+                    Reset
+                  </Button>
+                </div>
+              </form>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Current Status</CardTitle>
+              <CardDescription>
+                Active LAN and DHCP values reported by the modem.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ValueRow
+                label="DHCP"
+                value={
+                  <Badge variant={data.dhcp.enabled ? "success" : "secondary"}>
+                    {data.dhcp.enabled ? "Enabled" : "Disabled"}
+                  </Badge>
+                }
+              />
+              <ValueRow label="Gateway" value={data.lan.ip_address || "-"} />
+              <ValueRow label="Subnet" value={data.lan.subnet_mask || "-"} />
+              <ValueRow
+                label="DHCP Pool"
+                value={`${data.dhcp.start_ip || "-"} - ${data.dhcp.end_ip || "-"}`}
+              />
+              <ValueRow
+                label="Lease"
+                value={formatLease(data.dhcp.lease_time_seconds)}
+              />
+              <ValueRow
+                label="bridge0"
+                value={`${data.lan.bridge0.state || "unknown"} ${
+                  data.lan.bridge0.ipv4_cidr || ""
+                }`}
+              />
+              <ValueRow
+                label="eth0"
+                value={`${data.lan.eth0.state || "unknown"} ${
+                  data.lan.eth0.ipv4_cidr || ""
+                }`}
+              />
+            </CardContent>
+          </Card>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/hooks/use-lan-config.ts
+++ b/hooks/use-lan-config.ts
@@ -1,0 +1,115 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { authFetch } from "@/lib/auth-fetch";
+import type {
+  LanConfigResponse,
+  LanConfigSaveRequest,
+  LanConfigSaveResponse,
+} from "@/types/lan-config";
+
+const CGI_ENDPOINT = "/cgi-bin/quecmanager/network/lan_config.sh";
+
+export function useLanConfig() {
+  const [data, setData] = useState<LanConfigResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const fetchConfig = useCallback(async (silent = false) => {
+    if (silent) {
+      setIsRefreshing(true);
+    } else {
+      setIsLoading(true);
+    }
+    setError(null);
+
+    try {
+      const resp = await authFetch(CGI_ENDPOINT);
+      if (!resp.ok) {
+        throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
+      }
+
+      const result: LanConfigResponse = await resp.json();
+      if (!mountedRef.current) return;
+
+      if (!result.success) {
+        setError(result.detail || result.error || "Failed to fetch LAN config");
+        return;
+      }
+
+      setData(result);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError(err instanceof Error ? err.message : "Failed to fetch LAN config");
+    } finally {
+      if (!mountedRef.current) return;
+      setIsLoading(false);
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchConfig();
+  }, [fetchConfig]);
+
+  const saveConfig = useCallback(
+    async (
+      settings: Omit<LanConfigSaveRequest, "action">,
+    ): Promise<LanConfigSaveResponse | null> => {
+      setIsSaving(true);
+      setError(null);
+
+      try {
+        const resp = await authFetch(CGI_ENDPOINT, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action: "save", ...settings }),
+        });
+
+        if (!resp.ok) {
+          throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
+        }
+
+        const result: LanConfigSaveResponse = await resp.json();
+        if (!mountedRef.current) return null;
+
+        if (!result.success) {
+          setError(result.detail || result.error || "Failed to save LAN config");
+          return result;
+        }
+
+        await fetchConfig(true);
+        return result;
+      } catch (err) {
+        if (!mountedRef.current) return null;
+        setError(err instanceof Error ? err.message : "Failed to save LAN config");
+        return null;
+      } finally {
+        if (mountedRef.current) {
+          setIsSaving(false);
+        }
+      }
+    },
+    [fetchConfig],
+  );
+
+  return {
+    data,
+    isLoading,
+    isRefreshing,
+    isSaving,
+    error,
+    refresh: () => fetchConfig(true),
+    saveConfig,
+  };
+}

--- a/scripts/etc/sudoers.d/qmanager
+++ b/scripts/etc/sudoers.d/qmanager
@@ -31,3 +31,6 @@ www-data ALL=(root) NOPASSWD: /bin/rm -f /lib/systemd/system/multi-user.target.w
 
 # Web console management
 www-data ALL=(root) NOPASSWD: /usr/bin/qmanager_console_mgr
+
+# LAN/DHCP XML management
+www-data ALL=(root) NOPASSWD: /usr/bin/qmanager_lan_config_mgr

--- a/scripts/usr/bin/qmanager_lan_config_mgr
+++ b/scripts/usr/bin/qmanager_lan_config_mgr
@@ -1,0 +1,146 @@
+#!/bin/sh
+# qmanager_lan_config_mgr — Privileged LAN/DHCP XML writer.
+# Called by www-data CGI via sudo. Whitelisted in sudoers.
+
+CONFIG_FILE="/etc/data/mobileap_cfg.xml"
+
+json_error() {
+    jq -n --arg error "$1" --arg detail "$2" \
+        '{success:false,error:$error,detail:$detail}'
+}
+
+valid_ip() {
+    printf '%s' "$1" | awk -F. '
+        NF != 4 { exit 1 }
+        {
+            for (i = 1; i <= 4; i++) {
+                if ($i !~ /^[0-9]+$/ || $i < 0 || $i > 255) exit 1
+            }
+        }'
+}
+
+valid_netmask() {
+    case "$1" in
+        255.255.255.255|255.255.255.254|255.255.255.252|255.255.255.248|255.255.255.240|255.255.255.224|255.255.255.192|255.255.255.128|255.255.255.0|255.255.254.0|255.255.252.0|255.255.248.0|255.255.240.0|255.255.224.0|255.255.192.0|255.255.128.0|255.255.0.0|255.254.0.0|255.252.0.0|255.248.0.0|255.240.0.0|255.224.0.0|255.192.0.0|255.128.0.0|255.0.0.0) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+ip_le() {
+    awk -v a="$1" -v b="$2" 'BEGIN {
+        split(a, aa, "."); split(b, bb, ".");
+        ai = aa[1] * 16777216 + aa[2] * 65536 + aa[3] * 256 + aa[4];
+        bi = bb[1] * 16777216 + bb[2] * 65536 + bb[3] * 256 + bb[4];
+        exit !(ai <= bi)
+    }'
+}
+
+xml_escape() {
+    printf '%s' "$1" | sed 's/&/\\&amp;/g; s/</\\&lt;/g; s/>/\\&gt;/g'
+}
+
+write_config() {
+    lan_ip="$1"
+    subnet_mask="$2"
+    dhcp_enabled="$3"
+    dhcp_start="$4"
+    dhcp_end="$5"
+    lease_time="$6"
+
+    tmp="${CONFIG_FILE}.tmp.$$"
+    mode=$(stat -c '%a' "$CONFIG_FILE" 2>/dev/null || echo 755)
+    owner=$(stat -c '%U' "$CONFIG_FILE" 2>/dev/null || echo radio)
+    group=$(stat -c '%G' "$CONFIG_FILE" 2>/dev/null || echo radio)
+
+    sed \
+        -e "s|<APIPAddr>.*</APIPAddr>|<APIPAddr>$(xml_escape "$lan_ip")</APIPAddr>|" \
+        -e "s|<SubNetMask>.*</SubNetMask>|<SubNetMask>$(xml_escape "$subnet_mask")</SubNetMask>|" \
+        -e "s|<EnableDHCPServer>.*</EnableDHCPServer>|<EnableDHCPServer>$(xml_escape "$dhcp_enabled")</EnableDHCPServer>|" \
+        -e "s|<StartIP>.*</StartIP>|<StartIP>$(xml_escape "$dhcp_start")</StartIP>|" \
+        -e "s|<EndIP>.*</EndIP>|<EndIP>$(xml_escape "$dhcp_end")</EndIP>|" \
+        -e "s|<LeaseTime>.*</LeaseTime>|<LeaseTime>$(xml_escape "$lease_time")</LeaseTime>|" \
+        "$CONFIG_FILE" > "$tmp" || {
+            rm -f "$tmp"
+            return 1
+        }
+
+    chmod "$mode" "$tmp" 2>/dev/null || true
+    chown "$owner:$group" "$tmp" 2>/dev/null || true
+
+    mv "$tmp" "$CONFIG_FILE" || {
+        rm -f "$tmp"
+        return 1
+    }
+    sync
+}
+
+if [ "$(id -u)" -ne 0 ]; then
+    json_error "not_root" "qmanager_lan_config_mgr must run as root"
+    exit 1
+fi
+
+if [ "${1:-}" != "save" ]; then
+    json_error "invalid_action" "Usage: qmanager_lan_config_mgr save"
+    exit 1
+fi
+
+POST_DATA=$(cat)
+
+lan_ip=$(printf '%s' "$POST_DATA" | jq -r '.lan_ip // empty')
+subnet_mask=$(printf '%s' "$POST_DATA" | jq -r '.subnet_mask // empty')
+dhcp_enabled_raw=$(printf '%s' "$POST_DATA" | jq -r '.dhcp_enabled // empty')
+dhcp_start=$(printf '%s' "$POST_DATA" | jq -r '.dhcp_start // empty')
+dhcp_end=$(printf '%s' "$POST_DATA" | jq -r '.dhcp_end // empty')
+lease_time=$(printf '%s' "$POST_DATA" | jq -r '.lease_time_seconds // empty')
+
+if ! valid_ip "$lan_ip"; then json_error "invalid_lan_ip" "lan_ip must be a valid IPv4 address"; exit 1; fi
+if ! valid_netmask "$subnet_mask"; then json_error "invalid_subnet_mask" "subnet_mask must be a valid contiguous IPv4 netmask"; exit 1; fi
+if ! valid_ip "$dhcp_start"; then json_error "invalid_dhcp_start" "dhcp_start must be a valid IPv4 address"; exit 1; fi
+if ! valid_ip "$dhcp_end"; then json_error "invalid_dhcp_end" "dhcp_end must be a valid IPv4 address"; exit 1; fi
+if ! ip_le "$dhcp_start" "$dhcp_end"; then json_error "invalid_dhcp_range" "dhcp_start must be lower than or equal to dhcp_end"; exit 1; fi
+
+case "$dhcp_enabled_raw" in
+    true|1) dhcp_enabled=1 ;;
+    false|0) dhcp_enabled=0 ;;
+    *) json_error "invalid_dhcp_enabled" "dhcp_enabled must be boolean"; exit 1 ;;
+esac
+
+case "$lease_time" in
+    ''|*[!0-9]*) json_error "invalid_lease_time" "lease_time_seconds must be numeric"; exit 1 ;;
+esac
+if [ "$lease_time" -lt 60 ] || [ "$lease_time" -gt 604800 ]; then
+    json_error "invalid_lease_time" "lease_time_seconds must be between 60 and 604800"
+    exit 1
+fi
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    json_error "missing_config" "mobileap_cfg.xml not found"
+    exit 1
+fi
+
+if ! write_config "$lan_ip" "$subnet_mask" "$dhcp_enabled" "$dhcp_start" "$dhcp_end" "$lease_time"; then
+    json_error "write_failed" "Failed to write mobileap_cfg.xml"
+    exit 1
+fi
+
+at_applied=false
+at_warning=""
+at_result=$(qcmd "AT+QMAP=\"LANIP\",${dhcp_start},${dhcp_end},${lan_ip}" 2>/dev/null)
+case "$at_result" in
+    *ERROR*|'')
+        at_warning="AT+QMAP LANIP was not accepted; reboot may be required"
+        ;;
+    *)
+        at_applied=true
+        ;;
+esac
+
+jq -n \
+    --argjson at_applied "$at_applied" \
+    --arg at_warning "$at_warning" \
+    '{
+        success: true,
+        reboot_required: true,
+        at_lanip_applied: $at_applied,
+        at_lanip_warning: (if $at_warning == "" then null else $at_warning end)
+    }'

--- a/scripts/www/cgi-bin/quecmanager/network/lan_config.sh
+++ b/scripts/www/cgi-bin/quecmanager/network/lan_config.sh
@@ -1,0 +1,233 @@
+#!/bin/sh
+. /usr/lib/qmanager/cgi_base.sh
+. /usr/lib/qmanager/cgi_at.sh
+
+qlog_init "cgi_lan_config"
+cgi_headers
+cgi_handle_options
+
+CONFIG_FILE="/etc/data/mobileap_cfg.xml"
+
+xml_get() {
+    key="$1"
+    file="$2"
+    [ -f "$file" ] || return 0
+    sed -n "s/.*<$key>\\(.*\\)<\\/$key>.*/\\1/p" "$file" | head -1 | tr -d ' \r\n'
+}
+
+iface_addr() {
+    iface="$1"
+    ip -4 addr show "$iface" 2>/dev/null | awk '/inet /{print $2; exit}'
+}
+
+iface_state() {
+    iface="$1"
+    [ -e "/sys/class/net/$iface/operstate" ] && cat "/sys/class/net/$iface/operstate" || printf 'unknown'
+}
+
+valid_ip() {
+    printf '%s' "$1" | awk -F. '
+        NF != 4 { exit 1 }
+        {
+            for (i = 1; i <= 4; i++) {
+                if ($i !~ /^[0-9]+$/ || $i < 0 || $i > 255) exit 1
+            }
+        }'
+}
+
+valid_netmask() {
+    case "$1" in
+        255.255.255.255|255.255.255.254|255.255.255.252|255.255.255.248|255.255.255.240|255.255.255.224|255.255.255.192|255.255.255.128|255.255.255.0|255.255.254.0|255.255.252.0|255.255.248.0|255.255.240.0|255.255.224.0|255.255.192.0|255.255.128.0|255.255.0.0|255.254.0.0|255.252.0.0|255.248.0.0|255.240.0.0|255.224.0.0|255.192.0.0|255.128.0.0|255.0.0.0) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+ip_le() {
+    awk -v a="$1" -v b="$2" 'BEGIN {
+        split(a, aa, "."); split(b, bb, ".");
+        ai = aa[1] * 16777216 + aa[2] * 65536 + aa[3] * 256 + aa[4];
+        bi = bb[1] * 16777216 + bb[2] * 65536 + bb[3] * 256 + bb[4];
+        exit !(ai <= bi)
+    }'
+}
+
+xml_escape() {
+    printf '%s' "$1" | sed 's/&/\\&amp;/g; s/</\\&lt;/g; s/>/\\&gt;/g'
+}
+
+write_config() {
+    lan_ip="$1"
+    subnet_mask="$2"
+    dhcp_enabled="$3"
+    dhcp_start="$4"
+    dhcp_end="$5"
+    lease_time="$6"
+
+    tmp="${CONFIG_FILE}.tmp.$$"
+    mode=$(stat -c '%a' "$CONFIG_FILE" 2>/dev/null || echo 755)
+    owner=$(stat -c '%U' "$CONFIG_FILE" 2>/dev/null || echo radio)
+    group=$(stat -c '%G' "$CONFIG_FILE" 2>/dev/null || echo radio)
+
+    sed \
+        -e "s|<APIPAddr>.*</APIPAddr>|<APIPAddr>$(xml_escape "$lan_ip")</APIPAddr>|" \
+        -e "s|<SubNetMask>.*</SubNetMask>|<SubNetMask>$(xml_escape "$subnet_mask")</SubNetMask>|" \
+        -e "s|<EnableDHCPServer>.*</EnableDHCPServer>|<EnableDHCPServer>$(xml_escape "$dhcp_enabled")</EnableDHCPServer>|" \
+        -e "s|<StartIP>.*</StartIP>|<StartIP>$(xml_escape "$dhcp_start")</StartIP>|" \
+        -e "s|<EndIP>.*</EndIP>|<EndIP>$(xml_escape "$dhcp_end")</EndIP>|" \
+        -e "s|<LeaseTime>.*</LeaseTime>|<LeaseTime>$(xml_escape "$lease_time")</LeaseTime>|" \
+        "$CONFIG_FILE" > "$tmp" || {
+            rm -f "$tmp"
+            return 1
+        }
+
+    chmod "$mode" "$tmp" 2>/dev/null || true
+    chown "$owner:$group" "$tmp" 2>/dev/null || true
+
+    mv "$tmp" "$CONFIG_FILE" || {
+        rm -f "$tmp"
+        return 1
+    }
+    sync
+}
+
+if [ "$REQUEST_METHOD" = "GET" ]; then
+    if [ ! -f "$CONFIG_FILE" ]; then
+        cgi_error "missing_config" "mobileap_cfg.xml not found"
+        exit 0
+    fi
+
+    lanip_raw=$(qcmd 'AT+QMAP="LANIP"' 2>/dev/null | tr -d '\r')
+    lanip_line=$(printf '%s\n' "$lanip_raw" | grep '+QMAP:.*"LANIP"' | head -1)
+    at_start=$(printf '%s' "$lanip_line" | awk -F',' '{gsub(/"| /,"",$2); print $2}')
+    at_end=$(printf '%s' "$lanip_line" | awk -F',' '{gsub(/"| /,"",$3); print $3}')
+    at_gateway=$(printf '%s' "$lanip_line" | awk -F',' '{gsub(/"| /,"",$4); print $4}')
+
+    jq -n \
+        --arg config_file "$CONFIG_FILE" \
+        --arg ap_ip "$(xml_get APIPAddr "$CONFIG_FILE")" \
+        --arg assign_ap_ip "$(xml_get AssignAPIPAddr "$CONFIG_FILE")" \
+        --arg subnet_mask "$(xml_get SubNetMask "$CONFIG_FILE")" \
+        --arg dhcp_enabled "$(xml_get EnableDHCPServer "$CONFIG_FILE")" \
+        --arg dhcp_start "$(xml_get StartIP "$CONFIG_FILE")" \
+        --arg dhcp_end "$(xml_get EndIP "$CONFIG_FILE")" \
+        --arg lease_time "$(xml_get LeaseTime "$CONFIG_FILE")" \
+        --arg ippt_enabled "$(xml_get IPPassthroughEnable "$CONFIG_FILE")" \
+        --arg ippt_device_type "$(xml_get IPPassthroughDeviceType "$CONFIG_FILE")" \
+        --arg ippt_hostname "$(xml_get IPPassthroughHostName "$CONFIG_FILE")" \
+        --arg ippt_mac "$(xml_get IPPassthroughMacAddr "$CONFIG_FILE")" \
+        --arg ql_ippt_nat_pdn "$(xml_get QL_IPPassthroughFeatureWithNATPDN "$CONFIG_FILE")" \
+        --arg at_start "$at_start" \
+        --arg at_end "$at_end" \
+        --arg at_gateway "$at_gateway" \
+        --arg bridge0_addr "$(iface_addr bridge0)" \
+        --arg eth0_addr "$(iface_addr eth0)" \
+        --arg bridge0_state "$(iface_state bridge0)" \
+        --arg eth0_state "$(iface_state eth0)" \
+        --arg has_xmlstarlet "$(command -v xmlstarlet >/dev/null 2>&1 && echo true || echo false)" \
+        '{
+          success: true,
+          mode: "read_write",
+          config_file: $config_file,
+          tools: { xmlstarlet_available: ($has_xmlstarlet == "true") },
+          lan: {
+            ip_address: $ap_ip,
+            assign_ip_address: ($assign_ap_ip == "1"),
+            subnet_mask: $subnet_mask,
+            bridge0: { state: $bridge0_state, ipv4_cidr: $bridge0_addr },
+            eth0: { state: $eth0_state, ipv4_cidr: $eth0_addr }
+          },
+          dhcp: {
+            enabled: ($dhcp_enabled == "1"),
+            start_ip: $dhcp_start,
+            end_ip: $dhcp_end,
+            lease_time_seconds: (try ($lease_time | tonumber) catch null)
+          },
+          ip_passthrough_xml: {
+            enabled: ($ippt_enabled == "1"),
+            device_type: $ippt_device_type,
+            host_name: $ippt_hostname,
+            mac_address: $ippt_mac,
+            nat_pdn: $ql_ippt_nat_pdn
+          },
+          modem_lanip_at: {
+            command: "AT+QMAP=\"LANIP\"",
+            dhcp_start_ip: $at_start,
+            dhcp_end_ip: $at_end,
+            gateway_ip: $at_gateway
+          },
+          supported_future_writes: ["APIPAddr", "SubNetMask", "EnableDHCPServer", "StartIP", "EndIP", "LeaseTime"],
+          apply_notes: [
+            "Writes update /etc/data/mobileap_cfg.xml atomically",
+            "The endpoint also attempts AT+QMAP=\"LANIP\",start,end,gateway after saving",
+            "If the live AT apply is not accepted, reboot the modem to load XML changes"
+          ]
+        }'
+    exit 0
+fi
+
+if [ "$REQUEST_METHOD" = "POST" ]; then
+    cgi_read_post
+    action=$(printf '%s' "$POST_DATA" | jq -r '.action // empty')
+
+    if [ "$action" != "save" ]; then
+        cgi_error "invalid_action" "action must be save"
+        exit 0
+    fi
+
+    lan_ip=$(printf '%s' "$POST_DATA" | jq -r '.lan_ip // empty')
+    subnet_mask=$(printf '%s' "$POST_DATA" | jq -r '.subnet_mask // empty')
+    dhcp_enabled_raw=$(printf '%s' "$POST_DATA" | jq -r '.dhcp_enabled // empty')
+    dhcp_start=$(printf '%s' "$POST_DATA" | jq -r '.dhcp_start // empty')
+    dhcp_end=$(printf '%s' "$POST_DATA" | jq -r '.dhcp_end // empty')
+    lease_time=$(printf '%s' "$POST_DATA" | jq -r '.lease_time_seconds // empty')
+
+    if ! valid_ip "$lan_ip"; then
+        cgi_error "invalid_lan_ip" "lan_ip must be a valid IPv4 address"
+        exit 0
+    fi
+    if ! valid_netmask "$subnet_mask"; then
+        cgi_error "invalid_subnet_mask" "subnet_mask must be a valid contiguous IPv4 netmask"
+        exit 0
+    fi
+    if ! valid_ip "$dhcp_start"; then
+        cgi_error "invalid_dhcp_start" "dhcp_start must be a valid IPv4 address"
+        exit 0
+    fi
+    if ! valid_ip "$dhcp_end"; then
+        cgi_error "invalid_dhcp_end" "dhcp_end must be a valid IPv4 address"
+        exit 0
+    fi
+    if ! ip_le "$dhcp_start" "$dhcp_end"; then
+        cgi_error "invalid_dhcp_range" "dhcp_start must be lower than or equal to dhcp_end"
+        exit 0
+    fi
+    case "$dhcp_enabled_raw" in
+        true|1) dhcp_enabled=1 ;;
+        false|0) dhcp_enabled=0 ;;
+        *)
+            cgi_error "invalid_dhcp_enabled" "dhcp_enabled must be boolean"
+            exit 0
+            ;;
+    esac
+    case "$lease_time" in
+        ''|*[!0-9]*)
+            cgi_error "invalid_lease_time" "lease_time_seconds must be numeric"
+            exit 0
+            ;;
+    esac
+    if [ "$lease_time" -lt 60 ] || [ "$lease_time" -gt 604800 ]; then
+        cgi_error "invalid_lease_time" "lease_time_seconds must be between 60 and 604800"
+        exit 0
+    fi
+
+    helper_response=$(printf '%s' "$POST_DATA" | $_SUDO /usr/bin/qmanager_lan_config_mgr save 2>/dev/null)
+    if [ -z "$helper_response" ]; then
+        cgi_error "helper_failed" "Privileged LAN config helper failed"
+        exit 0
+    fi
+
+    printf '%s\n' "$helper_response"
+    exit 0
+fi
+
+cgi_method_not_allowed

--- a/types/lan-config.ts
+++ b/types/lan-config.ts
@@ -1,0 +1,64 @@
+// GET/POST /cgi-bin/quecmanager/network/lan_config.sh
+
+export interface LanInterfaceStatus {
+  state: string;
+  ipv4_cidr: string;
+}
+
+export interface LanConfigResponse {
+  success: boolean;
+  error?: string;
+  detail?: string;
+  mode: "read_only_discovery" | "read_write";
+  config_file: string;
+  tools: {
+    xmlstarlet_available: boolean;
+  };
+  lan: {
+    ip_address: string;
+    assign_ip_address: boolean;
+    subnet_mask: string;
+    bridge0: LanInterfaceStatus;
+    eth0: LanInterfaceStatus;
+  };
+  dhcp: {
+    enabled: boolean;
+    start_ip: string;
+    end_ip: string;
+    lease_time_seconds: number | null;
+  };
+  ip_passthrough_xml: {
+    enabled: boolean;
+    device_type: string;
+    host_name: string;
+    mac_address: string;
+    nat_pdn: string;
+  };
+  modem_lanip_at: {
+    command: string;
+    dhcp_start_ip: string;
+    dhcp_end_ip: string;
+    gateway_ip: string;
+  };
+  supported_future_writes: string[];
+  apply_notes: string[];
+}
+
+export interface LanConfigSaveRequest {
+  action: "save";
+  lan_ip: string;
+  subnet_mask: string;
+  dhcp_enabled: boolean;
+  dhcp_start: string;
+  dhcp_end: string;
+  lease_time_seconds: number;
+}
+
+export interface LanConfigSaveResponse {
+  success: boolean;
+  error?: string;
+  detail?: string;
+  reboot_required?: boolean;
+  at_lanip_applied?: boolean;
+  at_lanip_warning?: string;
+}


### PR DESCRIPTION
## Summary

Adds LAN/DHCP configuration support for RM520N-GL/Yocto devices.

- Adds a `Local Network -> LAN / DHCP` page with editable LAN IP, subnet mask, DHCP enable, DHCP pool, and lease time.
- Adds a CGI endpoint for reading current MobileAP LAN/DHCP state from `/etc/data/mobileap_cfg.xml` and `AT+QMAP="LANIP"`.
- Adds a privileged helper for safe writes to `mobileap_cfg.xml`, whitelisted through sudoers, and applies the active LANIP range through QMAP.
- Keeps IP passthrough and low-level MobileAP fields out of the LAN page to avoid mixing unrelated network modes.

## Validation

- `sh -n scripts/www/cgi-bin/quecmanager/network/lan_config.sh`
- `sh -n scripts/usr/bin/qmanager_lan_config_mgr`
- `npm exec -- tsc --noEmit`
- `npx next build`
- Live modem smoke test against `192.168.225.1`: GET returned current LAN/DHCP config, POST with existing values succeeded with `at_lanip_applied: true`.
